### PR TITLE
Possible cmake improvements

### DIFF
--- a/heppyy/CMakeLists.txt
+++ b/heppyy/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is just an orchestration
-cmake_minimum_required(VERSION 3.13.5)
+cmake_minimum_required(VERSION 3.15)
 # SWIG: use SWIG_MODULE_NAME property.
 if(POLICY CMP0086)
   cmake_policy(SET CMP0086 NEW)

--- a/heppyy/cmake/heppyy_find_python.cmake
+++ b/heppyy/cmake/heppyy_find_python.cmake
@@ -1,4 +1,4 @@
-find_package(Python 3.6 REQUIRED COMPONENTS Interpreter Development NumPy)
+find_package(Python 3.6 REQUIRED COMPONENTS Interpreter Development.Module NumPy)
 if (Python_FOUND)
     message(STATUS "${Green}Python ver. ${Python_VERSION} found.${ColourReset}")
     set(HEPPY_PYTHON_FOUND True)


### PR DESCRIPTION
I was attempting to install and run `heppyy` on hiccup and ran into a few small issues. I use `pyenv` for managing python installations - it tends to be a bit more troublesome than standard python installs, but allows for more customization. The changes needed to support it are:

1. Bump the minimum CMake version. This uses a much better `find_python` approach. Otherwise, it doesn't find my installation. Note that you can always install cmake from pypi if the native one is too old.
2. Reduces the required components in `find_python`. Per [here](https://scikit-build-core.readthedocs.io/en/latest/faqs.html#finding-python), this should be enough. I'm not sure if cppyy has stricter requirements, but I was able to compile and test `heppyy` without error using this approach, so it seems okay as a baseline. I didn't test extensively what this difference implies, so feel free to drop this one (I think 1 is worth keeping because it shouldn't cost anything)